### PR TITLE
added an argument to plot.regsubsets

### DIFF
--- a/R/plot.subsets.R
+++ b/R/plot.subsets.R
@@ -1,6 +1,6 @@
 plot.regsubsets<-function(x,labels=obj$xnames,main=NULL,
                           scale=c("bic","Cp","adjr2","r2"),
-                          col=gray(seq(0,0.9,length=10)),...){
+                          col=gray(seq(0,0.9,length=10)),digits=2,...){
     obj<-x
     lsum<-summary(obj)
     par(mar=c(7,5,6,3)+0.1)
@@ -30,7 +30,7 @@ plot.regsubsets<-function(x,labels=obj$xnames,main=NULL,
     on.exit(par(las=laspar))
     par(las=2)
     axis(1,at=1:np,labels=labels)
-    axis(2,at=1:nmodels,labels=signif(yscale[index],2))
+    axis(2,at=1:nmodels,labels=signif(yscale[index],digits))
     
     if (!is.null(main))
         title(main=main)

--- a/man/plot.regsubsets.Rd
+++ b/man/plot.regsubsets.Rd
@@ -3,7 +3,7 @@
 %- Also NEED an `\alias' for EACH other topic documented here.
 \title{Graphical table of best subsets}
 \usage{
-\method{plot}{regsubsets}(x, labels=obj$xnames, main=NULL, scale=c("bic", "Cp", "adjr2", "r2"), col=gray(seq(0, 0.9, length = 10)),...)
+\method{plot}{regsubsets}(x, labels=obj$xnames, main=NULL, scale=c("bic", "Cp", "adjr2", "r2"), col=gray(seq(0, 0.9, length = 10)), digits=2,...)
 }
 %- maybe also `usage' for other objects documented here.
 \arguments{
@@ -13,6 +13,7 @@
  \item{scale}{which summary statistic to use for ordering plots}
  \item{col}{Colors: the last color should be close to but distinct from
    white }
+ \item{digits}{amount of digits to display on the y axis }
  \item{...}{other arguments}
 }
 \description{


### PR DESCRIPTION
`digits` allows for the ability to define the amount of digits on the y axis of the plot. This is helpful especially when using `scale=adjr2` where a lot of different combinations can fall within the same two digit range and a more precise notation is needed.